### PR TITLE
Add support for Boolean and Integer property types. 

### DIFF
--- a/src/GoogleSheetsWrapper/BaseRepository.cs
+++ b/src/GoogleSheetsWrapper/BaseRepository.cs
@@ -112,6 +112,13 @@ namespace GoogleSheetsWrapper
 
             return records;
         }
+        public BatchUpdateSpreadsheetResponse SaveFields(T record, Expression<Func<T, object>> property1,
+            Expression<Func<T, object>> property2)
+            => SaveFields(record, new[] { property1, property2 });
+
+        public BatchUpdateSpreadsheetResponse SaveFields(T record, Expression<Func<T, object>> property1,
+            Expression<Func<T, object>> property2, Expression<Func<T, object>> property3)
+            => SaveFields(record, new[] { property1, property2, property3 });
 
         /// <summary>
         /// Save multiple field values to the row
@@ -119,7 +126,7 @@ namespace GoogleSheetsWrapper
         /// <param name="record"></param>
         /// <param name="properties"></param>
         /// <returns></returns>
-        public BatchUpdateSpreadsheetResponse SaveFields(T record, List<Expression<Func<T, object>>> properties)
+        public BatchUpdateSpreadsheetResponse SaveFields(T record, IList<Expression<Func<T, object>>> properties)
         {
             var data = record.ConvertToCellData(this.SheetsHelper.TabName);
 
@@ -136,7 +143,7 @@ namespace GoogleSheetsWrapper
         /// <returns></returns>
         public BatchUpdateSpreadsheetResponse SaveField(T record, Expression<Func<T, object>> expression)
         {
-            return this.SaveFields(record, new List<Expression<Func<T, object>>>() { expression });
+            return this.SaveFields(record, new Expression<Func<T, object>>[] { expression });
         }
 
         /// <summary>
@@ -203,7 +210,7 @@ namespace GoogleSheetsWrapper
         /// <returns></returns>
         internal List<BatchUpdateRequestObject> FilterUpdates(
             List<BatchUpdateRequestObject> data,
-            List<Expression<Func<T, object>>> expressions)
+            IList<Expression<Func<T, object>>> expressions)
         {
             var result = new List<BatchUpdateRequestObject>();
 

--- a/src/GoogleSheetsWrapper/SheetFieldAttribute.cs
+++ b/src/GoogleSheetsWrapper/SheetFieldAttribute.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace GoogleSheetsWrapper
 {
+    /// <summary>
+    /// These fields MUST match header of sheet fields.
+    /// </summary>
     public class SheetFieldAttribute : Attribute
     {
         protected static Dictionary<SheetFieldType, string> DefaultFormatPatterns = new Dictionary<SheetFieldType, string>()
@@ -13,6 +15,8 @@ namespace GoogleSheetsWrapper
             { SheetFieldType.PhoneNumber, "(###)\" \"###\"-\"####" },
             { SheetFieldType.DateTime, "M/d/yyyy H:mm:ss" },
             { SheetFieldType.Currency, "\"$\"#,##0.00" },
+            { SheetFieldType.Boolean, "#" },
+            { SheetFieldType.Integer, "#" },
         };
 
         /// <summary>
@@ -61,6 +65,8 @@ namespace GoogleSheetsWrapper
         DateTime,
         Currency,
         PhoneNumber,
+        Boolean,
+        Integer,
         Number
     }
 }

--- a/src/GoogleSheetsWrapper/SheetFieldAttributeUtils.cs
+++ b/src/GoogleSheetsWrapper/SheetFieldAttributeUtils.cs
@@ -63,9 +63,21 @@ namespace GoogleSheetsWrapper
                         if (!string.IsNullOrWhiteSpace(stringValue))
                         {
                             var value = double.Parse(stringValue);
-
                             property.SetValue(record, value);
                         }
+                    }
+                    else if (attribute.FieldType == SheetFieldType.Integer)
+                    {
+                        if(!string.IsNullOrWhiteSpace(stringValue))
+                        {
+                            int value = int.Parse(stringValue);
+                            property.SetValue(record, value);
+                        }
+                    }
+                    else if (attribute.FieldType == SheetFieldType.Boolean)
+                    {
+                        bool boolValue = Convert.ToBoolean(stringValue);
+                        property.SetValue(record, boolValue);
                     }
                     else
                     {
@@ -172,6 +184,31 @@ namespace GoogleSheetsWrapper
                         Type = "NUMBER"
                     }
                 };
+            }
+            else if (attribute.FieldType == SheetFieldType.Integer)
+            {
+                if(value != null)
+                {
+                    cell.UserEnteredValue.NumberValue = (int)value;
+                }
+
+                cell.UserEnteredFormat = new CellFormat()
+                {
+                    NumberFormat = new NumberFormat()
+                    {
+                        Pattern = attribute.NumberFormatPattern,
+                        Type = "NUMBER"
+                    }
+                };
+            }
+            else if (attribute.FieldType == SheetFieldType.Boolean)
+            {
+                if(value != null)
+                {
+                    cell.UserEnteredValue.BoolValue = (bool)value;
+                }
+
+                cell.UserEnteredFormat = new CellFormat();
             }
             else
             {


### PR DESCRIPTION
Bools now get stored into Sheets as "TRUE" or "FALSE" and are parsed appropriately.
Changed List<Expression<Func<T, object>>> to IList<Expression<Func<T, object>>> (IList) to support arrays in addition to Lists. Added a few overloads to SaveFields to support multiple properties inline, such as `repository.SaveFields(record, (r) => r.Owner, (r) => r.Username);`