### PR TITLE
Fix Sheets not showing '0' with Integer types

### DIFF
--- a/src/GoogleSheetsWrapper/SheetFieldAttribute.cs
+++ b/src/GoogleSheetsWrapper/SheetFieldAttribute.cs
@@ -16,7 +16,7 @@ namespace GoogleSheetsWrapper
             { SheetFieldType.DateTime, "M/d/yyyy H:mm:ss" },
             { SheetFieldType.Currency, "\"$\"#,##0.00" },
             { SheetFieldType.Boolean, "#" },
-            { SheetFieldType.Integer, "#" },
+            { SheetFieldType.Integer, "0" },
         };
 
         /// <summary>


### PR DESCRIPTION
This formatting symbol tells Sheets to display '0' instead of an empty cell when using the default formatting style "Automatic".