### PR TITLE
Change List<T> to IList<T> to also support arrays.

### DIFF
--- a/src/GoogleSheetsWrapper/BaseRepository.cs
+++ b/src/GoogleSheetsWrapper/BaseRepository.cs
@@ -95,7 +95,7 @@ namespace GoogleSheetsWrapper
         {
             var result = this.SheetsHelper.GetRows(SheetDataRange);
 
-            var records = new List<T>();
+            var records = new List<T>(result.Count);
 
             for (int r = 0; r < result.Count; r++)
             {

--- a/src/GoogleSheetsWrapper/BaseRepository.cs
+++ b/src/GoogleSheetsWrapper/BaseRepository.cs
@@ -73,7 +73,7 @@ namespace GoogleSheetsWrapper
         /// Create a list of records to the end of the current sheets table
         /// </summary>
         /// <param name="records"></param>
-        public BatchUpdateSpreadsheetResponse AddRecords(List<T> records)
+        public BatchUpdateSpreadsheetResponse AddRecords(IList<T> records)
         {
             return this.SheetsHelper.AppendRows(records);
         }

--- a/src/GoogleSheetsWrapper/SheetHelper.cs
+++ b/src/GoogleSheetsWrapper/SheetHelper.cs
@@ -397,7 +397,7 @@ namespace GoogleSheetsWrapper
 
         public BatchUpdateSpreadsheetResponse AppendRow(T record)
         {
-            return this.AppendRows(new List<T>() { record });
+            return this.AppendRows(new T[] { record });
         }
 
         public BatchUpdateSpreadsheetResponse AppendRows(IList<T> records)

--- a/src/GoogleSheetsWrapper/SheetHelper.cs
+++ b/src/GoogleSheetsWrapper/SheetHelper.cs
@@ -400,7 +400,7 @@ namespace GoogleSheetsWrapper
             return this.AppendRows(new List<T>() { record });
         }
 
-        public BatchUpdateSpreadsheetResponse AppendRows(List<T> records)
+        public BatchUpdateSpreadsheetResponse AppendRows(IList<T> records)
         {
             var rows = new List<RowData>();
 

--- a/src/GoogleSheetsWrapper/SheetHelper.cs
+++ b/src/GoogleSheetsWrapper/SheetHelper.cs
@@ -143,8 +143,6 @@ namespace GoogleSheetsWrapper
         /// <returns></returns>
         public BatchUpdateSpreadsheetResponse DeleteColumn(int col)
         {
-            var requests = new List<Request>();
-
             var request = new Request()
             {
                 DeleteDimension = new DeleteDimensionRequest()
@@ -159,11 +157,9 @@ namespace GoogleSheetsWrapper
                 }
             };
 
-            requests.Add(request);
-
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest
             {
-                Requests = requests
+                Requests = new [] { request }
             };
 
             var updateRequest = this.Service.Spreadsheets.BatchUpdate(bussr, this.SpreadsheetID);
@@ -189,8 +185,6 @@ namespace GoogleSheetsWrapper
         /// <returns></returns>
         public BatchUpdateSpreadsheetResponse DeleteRow(int row)
         {
-            var requests = new List<Request>();
-
             var request = new Request()
             {
                 DeleteDimension = new DeleteDimensionRequest()
@@ -205,11 +199,9 @@ namespace GoogleSheetsWrapper
                 }
             };
 
-            requests.Add(request);
-
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest
             {
-                Requests = requests
+                Requests = new [] { request }
             };
 
             var updateRequest = this.Service.Spreadsheets.BatchUpdate(bussr, this.SpreadsheetID);
@@ -224,8 +216,6 @@ namespace GoogleSheetsWrapper
         /// <returns></returns>
         public BatchUpdateSpreadsheetResponse DeleteRows(int startRow, int endRow)
         {
-            var requests = new List<Request>();
-
             var request = new Request()
             {
                 DeleteDimension = new DeleteDimensionRequest()
@@ -240,11 +230,9 @@ namespace GoogleSheetsWrapper
                 }
             };
 
-            requests.Add(request);
-
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest
             {
-                Requests = requests
+                Requests = new [] { request }
             };
 
             var updateRequest = this.Service.Spreadsheets.BatchUpdate(bussr, this.SpreadsheetID);
@@ -263,8 +251,6 @@ namespace GoogleSheetsWrapper
                 throw new ArgumentException("column index value must be 1 or greater");
             }
 
-            var requests = new List<Request>();
-
             var request = new Request()
             {
                 InsertDimension = new InsertDimensionRequest()
@@ -280,11 +266,9 @@ namespace GoogleSheetsWrapper
                 }
             };
 
-            requests.Add(request);
-
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest
             {
-                Requests = requests
+                    Requests = new [] { request }
             };
 
             var updateRequest = this.Service.Spreadsheets.BatchUpdate(bussr, this.SpreadsheetID);
@@ -315,8 +299,6 @@ namespace GoogleSheetsWrapper
                 throw new ArgumentException("row index value must be 1 or greater");
             }
 
-            var requests = new List<Request>();
-
             var request = new Request()
             {
                 InsertDimension = new InsertDimensionRequest()
@@ -332,11 +314,9 @@ namespace GoogleSheetsWrapper
                 }
             };
 
-            requests.Add(request);
-
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest
             {
-                Requests = requests
+                Requests = new [] { request }
             };
 
             var updateRequest = this.Service.Spreadsheets.BatchUpdate(bussr, this.SpreadsheetID);

--- a/src/GoogleSheetsWrapper/SheetHelper.cs
+++ b/src/GoogleSheetsWrapper/SheetHelper.cs
@@ -354,7 +354,7 @@ namespace GoogleSheetsWrapper
         {
             BatchUpdateSpreadsheetRequest bussr = new BatchUpdateSpreadsheetRequest();
 
-            var requests = new List<Request>();
+            var requests = new List<Request>(updates.Count);
 
             foreach (var update in updates)
             {
@@ -402,7 +402,7 @@ namespace GoogleSheetsWrapper
 
         public BatchUpdateSpreadsheetResponse AppendRows(IList<T> records)
         {
-            var rows = new List<RowData>();
+            var rows = new List<RowData>(records.Count);
 
             foreach (var record in records)
             {


### PR DESCRIPTION
Sometimes you have an array of Records but want to avoid converting to List. Some functions already supported arrays through IList<T>, so I updated the remaining methods that only supported List<T>. 

I changed some instances where a single-element List was created to send a single request, and changed the List to an array instead. While profiling the project I'm working on, I noticed these allocations can add up.

In addition, I used the List(int capacity) constructor over the default constructor when the size of the list was known.