### PR TITLE
Allow passing IHttpClientFactory to SheetHelper.Init to enable proxy support

### DIFF
--- a/src/GoogleSheetsWrapper/SheetHelper.cs
+++ b/src/GoogleSheetsWrapper/SheetHelper.cs
@@ -33,7 +33,8 @@ namespace GoogleSheetsWrapper
             this.ServiceAccountEmail = serviceAccountEmail;
             this.TabName = tabName;
         }
-        public void Init(string jsonCredentials)
+        public void Init(string jsonCredentials) => Init(jsonCredentials, default);
+        public void Init(string jsonCredentials, Google.Apis.Http.IHttpClientFactory httpClientFactory)
         {
             var credential = (ServiceAccountCredential)
                    GoogleCredential.FromJson(jsonCredentials).UnderlyingCredential;
@@ -43,13 +44,15 @@ namespace GoogleSheetsWrapper
             {
                 User = this.ServiceAccountEmail,
                 Key = credential.Key,
-                Scopes = Scopes
+                Scopes = Scopes,
+                HttpClientFactory = httpClientFactory,
             };
             credential = new ServiceAccountCredential(initializer);
 
             var service = new SheetsService(new BaseClientService.Initializer()
             {
                 HttpClientInitializer = credential,
+                HttpClientFactory = httpClientFactory,
             });
 
             this.Service = service;


### PR DESCRIPTION
I'm not sure about the implementation(i.e. public API probably shouldn't expose a google-specific type), but this solved the issue for my workflow.

Maybe, the new overload should take built in `System.Net.IWebProxy` or `System.Net.Http.HttpClientHandler` parameter instead, and wrap it with a factory internally, but I'm not sure if it's future-proof and covers all edge cases.