### PR TITLE
SheetAppender - change headers logic so that you can control to not append headers.

### DIFF
--- a/src/GoogleSheetsWrapper/SheetAppender.cs
+++ b/src/GoogleSheetsWrapper/SheetAppender.cs
@@ -50,12 +50,13 @@ namespace GoogleSheetsWrapper
         /// </summary>
         /// <param name="filePath"></param>
         /// <param name="includeHeaders"></param>
-        /// <param name="batchWaitTime"></param>
-        public void AppendCsv(string filePath, bool includeHeaders, int batchWaitTime = 1000)
+        /// <param name="batchWaitTime">See https://developers.google.com/sheets/api/limits at last check is 60 requests a minute, so 1 second delay per request should avoid limiting</param>
+        /// <param name="batchSize">Increasing batch size may improve throughput. Default is conservative.</param>
+        public void AppendCsv(string filePath, bool includeHeaders, int batchWaitTime = 1000, int batchSize = 100)
         {
             using (var stream = new FileStream(filePath, FileMode.Open))
             {
-                AppendCsv(stream, includeHeaders, batchWaitTime);
+                AppendCsv(stream, includeHeaders, batchWaitTime, batchSize);
             }
         }
 
@@ -64,15 +65,16 @@ namespace GoogleSheetsWrapper
         /// </summary>
         /// <param name="stream"></param>
         /// <param name="includeHeaders"></param>
-        /// <param name="batchWaitTime"></param>
-        public void AppendCsv(Stream stream, bool includeHeaders, int batchWaitTime = 1000)
+        /// <param name="batchWaitTime">See https://developers.google.com/sheets/api/limits at last check is 60 requests a minute, so 1 second delay per request should avoid limiting</param>
+        /// <param name="batchSize">Increasing batch size may improve throughput. Default is conservative.</param>
+        public void AppendCsv(Stream stream, bool includeHeaders, int batchWaitTime = 1000, int batchSize = 100)
         {
             var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
                 HasHeaderRecord = includeHeaders
             };
 
-            AppendCsv(stream, csvConfig, batchWaitTime);
+            AppendCsv(stream, csvConfig, batchWaitTime, batchSize);
         }
 
         /// <summary>
@@ -80,13 +82,14 @@ namespace GoogleSheetsWrapper
         /// </summary>
         /// <param name="stream"></param>
         /// <param name="csvConfig"></param>
-        /// <param name="batchWaitTime"></param>
-        public void AppendCsv(Stream stream, CsvConfiguration csvConfig, int batchWaitTime = 1000)
+        /// <param name="batchWaitTime">See https://developers.google.com/sheets/api/limits at last check is 60 requests a minute, so 1 second delay per request should avoid limiting</param>
+        /// <param name="batchSize">Increasing batch size may improve throughput. Default is conservative.</param>
+        public void AppendCsv(Stream stream, CsvConfiguration csvConfig, int batchWaitTime = 1000, int batchSize = 100)
         {
             using var streamReader = new StreamReader(stream);
             using var csv = new CsvReader(streamReader, csvConfig);
             {
-                var batchRowLimit = 100;
+                var batchRowLimit = batchSize;
 
                 var dataRecords =
                     csv.GetRecords<dynamic>()

--- a/src/GoogleSheetsWrapper/SheetAppender.cs
+++ b/src/GoogleSheetsWrapper/SheetAppender.cs
@@ -49,7 +49,7 @@ namespace GoogleSheetsWrapper
         /// Appends a CSV file and all its rows into the current Google Sheets tab
         /// </summary>
         /// <param name="filePath"></param>
-        /// <param name="includeHeaders"></param>
+        /// <param name="includeHeaders">If true include all rows, otherwise skip first row</param>
         /// <param name="batchWaitTime">See https://developers.google.com/sheets/api/limits at last check is 60 requests a minute, so 1 second delay per request should avoid limiting</param>
         /// <param name="batchSize">Increasing batch size may improve throughput. Default is conservative.</param>
         public void AppendCsv(string filePath, bool includeHeaders, int batchWaitTime = 1000, int batchSize = 100)
@@ -64,14 +64,14 @@ namespace GoogleSheetsWrapper
         /// Appends a CSV file and all its rows into the current Google Sheets tab
         /// </summary>
         /// <param name="stream"></param>
-        /// <param name="includeHeaders"></param>
+        /// <param name="includeHeaders">If true include all rows, otherwise skip first row</param>
         /// <param name="batchWaitTime">See https://developers.google.com/sheets/api/limits at last check is 60 requests a minute, so 1 second delay per request should avoid limiting</param>
         /// <param name="batchSize">Increasing batch size may improve throughput. Default is conservative.</param>
         public void AppendCsv(Stream stream, bool includeHeaders, int batchWaitTime = 1000, int batchSize = 100)
         {
             var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                HasHeaderRecord = includeHeaders
+                HasHeaderRecord = !includeHeaders
             };
 
             AppendCsv(stream, csvConfig, batchWaitTime, batchSize);
@@ -99,25 +99,6 @@ namespace GoogleSheetsWrapper
                 var rowData = new List<RowData>();
 
                 var currentBatchCount = 0;
-
-                if (csvConfig.HasHeaderRecord)
-                {
-                    currentBatchCount++;
-
-                    var row = new RowData()
-                    {
-                        Values = new List<CellData>()
-                    };
-
-                    var headers = csv.HeaderRecord;
-
-                    foreach (var header in headers)
-                    {
-                        row.Values.Add(StringToCellData(header));
-                    }
-
-                    rowData.Add(row);
-                }
 
                 foreach (var record in dataRecords)
                 {


### PR DESCRIPTION
A have a sheet for which I want to every day append a csv file to it.

On the first day I want to include the headers (rows = 0) after that I do not.

Currently whatever value you pass to includeHeaders, it will always include the header as it will either add the header via csv.HeaderRecord or read all the rows (including headerrow).

I've changed the behaviour so that when you pass includeHeader = false, the first row is essentially skipped.

I believe this is a bug of the current build, but my change could also be a breaking change.

I only have one sheet/csv that I've tested on, but the change is working for this.