### PR TITLE
update packages - DocumentFormat.OpenXml package had a vulnerability

### DIFF
--- a/src/GoogleSheetsWrapper/GoogleSheetsWrapper.csproj
+++ b/src/GoogleSheetsWrapper/GoogleSheetsWrapper.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
-    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.68.0.3476" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.68.0.3624" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GoogleSheetsWrapper/SheetAppender.cs
+++ b/src/GoogleSheetsWrapper/SheetAppender.cs
@@ -194,7 +194,7 @@ namespace GoogleSheetsWrapper
                     {
                         name = (nameAttribute as CsvHelper.Configuration.Attributes.NameAttribute).Names.FirstOrDefault() ?? name;
                     }
-                    row.Values.Add(StringToCellData(header.Name));
+                    row.Values.Add(StringToCellData(name));
                 }
 
                 rowData.Add(row);


### PR DESCRIPTION
New version of DocumentFormat.OpenXml uses System.IO.Packaging 8.0.1

Version 8.0.0 is marked as having a vulnerability